### PR TITLE
Enable API to allow uploaded channel logos

### DIFF
--- a/roles/xteve/defaults/main.yml
+++ b/roles/xteve/defaults/main.yml
@@ -49,6 +49,8 @@ xteve_traefik_middleware: "{{ traefik_default_middleware + ',' + xteve_traefik_s
                            else traefik_default_middleware }}"
 xteve_traefik_certresolver: "{{ traefik_default_certresolver }}"
 xteve_traefik_enabled: true
+xteve_traefik_api_enabled: true
+xteve_traefik_api_endpoint: "`/data_images`"
 
 ################################
 # Docker


### PR DESCRIPTION
# Description

If channel logos are manually uploaded, or if image caching is enabled, clients can't access them because of Authelia. This enables API and adds `/data_images` as an endpoint to allow clients to access these without being blocked by the middleware.

# How Has This Been Tested?

- [x] Tested on my production SB install.
- [x] Tested with Plex Live TV
- [x] Tested with Jellyfin Live TV